### PR TITLE
Don't limit autoload check to 4 stack frames

### DIFF
--- a/lib/dry/types/rails/railtie.rb
+++ b/lib/dry/types/rails/railtie.rb
@@ -11,7 +11,7 @@ module Dry
             # ActiveSupport::Dependencies.will_unload?(klass) won't return true yet
             #   if it's the first time a constant is being autoloaded
             #   so we have to see if we're in the middle of loading a missing constants
-            autoloaded |= caller(4).any? { |line| line =~ /\:in.*?new_constants_in/ }
+            autoloaded |= caller.any? { |line| line =~ /\:in.*?new_constants_in/ }
 
             REGISTERED_TYPES << klass if autoloaded
           end


### PR DESCRIPTION
I ran into some issues with this in some of my Rails apps.  Seems to make sense to just use the entire stack since you're in development mode anyway.
