### PR TITLE
dry-types >= 0.8 - fixes

### DIFF
--- a/dry-types-rails.gemspec
+++ b/dry-types-rails.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.4.0'
 
   spec.add_runtime_dependency 'rails', '>= 3'
-  spec.add_runtime_dependency 'dry-types'
+  spec.add_runtime_dependency 'dry-types', '>= 0.8.1'
 end

--- a/lib/dry/types/rails/railtie.rb
+++ b/lib/dry/types/rails/railtie.rb
@@ -4,18 +4,18 @@ module Dry
       module TypesRegistration
         REGISTERED_TYPES = Concurrent::Array.new
 
-        def register_class(klass, meth = :new)
-          return if TypesRegistration::REGISTERED_TYPES.include?(klass.to_s)
+        def register(name, type)
+          return if TypesRegistration::REGISTERED_TYPES.include?(name)
 
           super.tap do
             # Check to see if we need to remove the registered type
-            autoloaded = ActiveSupport::Dependencies.will_unload?(klass)
+            autoloaded = ActiveSupport::Dependencies.will_unload?(type)
             # ActiveSupport::Dependencies.will_unload?(klass) won't return true yet
             #   if it's the first time a constant is being autoloaded
             #   so we have to see if we're in the middle of loading a missing constants
             autoloaded |= caller.any? { |line| line =~ /\:in.*?new_constants_in/ }
 
-            TypesRegistration::REGISTERED_TYPES << klass.to_s if autoloaded
+            TypesRegistration::REGISTERED_TYPES << name if autoloaded
           end
         end
       end

--- a/lib/dry/types/rails/version.rb
+++ b/lib/dry/types/rails/version.rb
@@ -1,7 +1,7 @@
 module Dry
   module Types
     module Rails
-      VERSION = "0.3.2"
+      VERSION = "0.3.3"
     end
   end
 end

--- a/spec/dry/types/rails/railtie_spec.rb
+++ b/spec/dry/types/rails/railtie_spec.rb
@@ -95,10 +95,10 @@ describe Dry::Types::Rails::Railtie do
         end
 
         expect(Autoload::SchemaStruct).to respond_to(:previous_ref)
-        expect(Dry::Types[Autoload::SchemaStruct].primitive).to respond_to(:previous_ref)
+        expect(Dry::Types[Autoload::SchemaStruct]).to respond_to(:previous_ref)
         clear_autoload
         expect(Autoload::SchemaStruct).to_not respond_to(:previous_ref)
-        expect(Dry::Types[Autoload::SchemaStruct].primitive).to_not respond_to(:previous_ref)
+        expect(Dry::Types[Autoload::SchemaStruct]).to_not respond_to(:previous_ref)
       end
     end
   end


### PR DESCRIPTION
dry-types with version >= 0.8 doesn't use anymore `register_class`
method in favour of `register`.
